### PR TITLE
Allow to use the mailjet templates with the api

### DIFF
--- a/Transport/MailjetApiTransport.php
+++ b/Transport/MailjetApiTransport.php
@@ -128,6 +128,31 @@ class MailjetApiTransport extends AbstractApiTransport
             $message['Headers'][$header->getName()] = $header->getBodyAsString();
         }
 
+        if ($email instanceof MailjetTemplateEmail) {
+            if ($email->getTemplateId()) {
+                $payload['TemplateLanguage'] = true;
+                $payload['TemplateID'] = $email->getTemplateId();
+            }
+
+            if (count($email->getVariables())) {
+                $payload['Variables'] = $email->getVariables();
+            }
+
+            if ($email->getErrorReportingEmail()) {
+                $payload['TemplateErrorReporting'] = array(
+                    'Email' => $email->getErrorReportingEmail(),
+                );
+            }
+
+            if ($email->isTemplateErrorDeliver()) {
+                $payload['TemplateErrorDeliver'] = true;
+            }
+
+            if (count($email->getAdditionalProperties())) {
+                $payload = array_merge($payload, $email->getAdditionalProperties());
+            }
+        }
+
         return [
             'Messages' => [$message],
         ];

--- a/Transport/MailjetApiTransport.php
+++ b/Transport/MailjetApiTransport.php
@@ -61,7 +61,7 @@ class MailjetApiTransport extends AbstractApiTransport
             'headers' => [
                 'Accept' => 'application/json',
             ],
-            'auth_basic' => $this->publicKey.':'.$this->privateKey,
+            'auth_basic' => [$this->publicKey, $this->privateKey],
             'json' => $this->getPayload($email, $envelope),
         ]);
 
@@ -135,28 +135,32 @@ class MailjetApiTransport extends AbstractApiTransport
             $message['Headers'][$header->getName()] = $header->getBodyAsString();
         }
 
-        if ($email instanceof MailjetTemplateEmail) {
+        if ($email instanceof MailjetTemplatedEmail) {
+            if ($email->getCampaignName()) {
+                $message['CustomCampaign'] = $email->getCampaignName();
+            }
+
             if ($email->getTemplateId()) {
-                $payload['TemplateLanguage'] = true;
-                $payload['TemplateID'] = $email->getTemplateId();
+                $message['TemplateLanguage'] = true;
+                $message['TemplateID'] = $email->getTemplateId();
             }
 
             if (count($email->getVariables())) {
-                $payload['Variables'] = $email->getVariables();
+                $message['Variables'] = $email->getVariables();
             }
 
             if ($email->getErrorReportingEmail()) {
-                $payload['TemplateErrorReporting'] = array(
+                $message['TemplateErrorReporting'] = array(
                     'Email' => $email->getErrorReportingEmail(),
                 );
             }
 
             if ($email->isTemplateErrorDeliver()) {
-                $payload['TemplateErrorDeliver'] = true;
+                $message['TemplateErrorDeliver'] = true;
             }
 
             if (count($email->getAdditionalProperties())) {
-                $payload = array_merge($payload, $email->getAdditionalProperties());
+                $message = array_merge($message, $email->getAdditionalProperties());
             }
         }
 

--- a/Transport/MailjetTemplateEmail.php
+++ b/Transport/MailjetTemplateEmail.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Symfony\Component\Mailer\Bridge\Mailjet\Transport;
+
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Exception\LogicException;
+use Symfony\Component\Mime\Header\Headers;
+use Symfony\Component\Mime\Part\AbstractPart;
+
+class MailjetTemplateEmail extends Email
+{
+    protected $templateId = null;
+    protected $variables = array();
+    protected $errorReportingEmail = null;
+    protected $templateErrorDeliver = false;
+    protected $additionalProperties = array();
+
+    public function __construct(Headers $headers = null, AbstractPart $body = null)
+    {
+        parent::__construct($headers, $body);
+
+        $this->html('');
+        $this->text('');
+    }
+
+    public function getTemplateId()
+    {
+        return $this->templateId;
+    }
+
+    public function setTemplateId(int $templateId): self
+    {
+        $this->templateId = $templateId;
+
+        return $this;
+    }
+
+    public function getVariables(): array
+    {
+        return $this->variables;
+    }
+
+    public function setVariables(array $variables): self
+    {
+        $this->variables = $variables;
+
+        return $this;
+    }
+
+    public function setVariable(string $key, string $value): self
+    {
+        $this->variables[$key] = $value;
+
+        return $this;
+    }
+
+    public function getErrorReportingEmail()
+    {
+        return $this->errorReportingEmail;
+    }
+
+    public function setErrorReportingEmail(string $errorReportingEmail): self
+    {
+        $this->errorReportingEmail = $errorReportingEmail;
+
+        return $this;
+    }
+
+    public function isTemplateErrorDeliver(): bool
+    {
+        return $this->templateErrorDeliver;
+    }
+
+    public function setTemplateErrorDeliver(bool $templateErrorDeliver = true): self
+    {
+        $this->templateErrorDeliver = $templateErrorDeliver;
+
+        return $this;
+    }
+
+    public function getAdditionalProperties(): array
+    {
+        return $this->additionalProperties;
+    }
+
+    public function setAdditionalProperties(array $additionalProperties): self
+    {
+        $this->additionalProperties = $additionalProperties;
+
+        return $this;
+    }
+
+    public function addProperty(string $key, string $value): self
+    {
+        $this->additionalProperties[$key] = $value;
+
+        return $this;
+    }
+
+    public function ensureValidity()
+    {
+        if (null === $this->templateId) {
+            if (count($this->variables)) {
+                throw new \LogicException('A template id is required.');
+            }
+        }
+
+        parent::ensureValidity();
+    }
+
+    /**
+     * @internal
+     */
+    public function __serialize(): array
+    {
+        return [$this->templateId, $this->variables, $this->errorReportingEmail, $this->templateErrorDeliver, $this->additionalProperties, parent::__serialize()];
+    }
+
+    /**
+     * @internal
+     */
+    public function __unserialize(array $data): void
+    {
+        [$this->templateId, $this->variables, $this->errorReportingEmail, $this->templateErrorDeliver, $this->additionalProperties, $parentData] = $data;
+
+        parent::__unserialize($parentData);
+    }
+}

--- a/Transport/MailjetTemplatedEmail.php
+++ b/Transport/MailjetTemplatedEmail.php
@@ -9,6 +9,7 @@ use Symfony\Component\Mime\Part\AbstractPart;
 
 class MailjetTemplatedEmail extends Email
 {
+    protected $campaignName = null;
     protected $templateId = null;
     protected $variables = array();
     protected $errorReportingEmail = null;
@@ -21,6 +22,18 @@ class MailjetTemplatedEmail extends Email
 
         $this->html('');
         $this->text('');
+    }
+
+    public function getCampaignName()
+    {
+        return $this->campaignName;
+    }
+
+    public function setCampaignName(string $campaignName): self
+    {
+        $this->campaignName = $campaignName;
+
+        return $this;
     }
 
     public function getTemplateId()
@@ -113,7 +126,7 @@ class MailjetTemplatedEmail extends Email
      */
     public function __serialize(): array
     {
-        return [$this->templateId, $this->variables, $this->errorReportingEmail, $this->templateErrorDeliver, $this->additionalProperties, parent::__serialize()];
+        return [$this->campaignName, $this->templateId, $this->variables, $this->errorReportingEmail, $this->templateErrorDeliver, $this->additionalProperties, parent::__serialize()];
     }
 
     /**
@@ -121,7 +134,7 @@ class MailjetTemplatedEmail extends Email
      */
     public function __unserialize(array $data): void
     {
-        [$this->templateId, $this->variables, $this->errorReportingEmail, $this->templateErrorDeliver, $this->additionalProperties, $parentData] = $data;
+        [$this->campaignName, $this->templateId, $this->variables, $this->errorReportingEmail, $this->templateErrorDeliver, $this->additionalProperties, $parentData] = $data;
 
         parent::__unserialize($parentData);
     }

--- a/Transport/MailjetTemplatedEmail.php
+++ b/Transport/MailjetTemplatedEmail.php
@@ -7,7 +7,7 @@ use Symfony\Component\Mime\Exception\LogicException;
 use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Part\AbstractPart;
 
-class MailjetTemplateEmail extends Email
+class MailjetTemplatedEmail extends Email
 {
     protected $templateId = null;
     protected $variables = array();


### PR DESCRIPTION
This PR allow using [mailjet templates](https://dev.mailjet.com/email/guides/template-api/).

To do this, I extended the `Symfony\Component\Mime\Email` and created a `Symfony\Component\Mailer\Bridge\Mailjet\Transport\MailjetTemplatedEmail`

Feel free to guide me on how to make this PR merged!

Thanks