### PR TITLE
MailjetApiTransport Sandbox Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Configuration examples:
 ```dotenv
 # API
 MAILER_DSN=mailjet+api://$PUBLIC_KEY:$PRIVATE_KEY@default
+MAILER_DSN=mailjet+api://$PUBLIC_KEY:$PRIVATE_KEY@default?sandbox=true
 # SMTP
 MAILER_DSN=mailjet+smtp://$PUBLIC_KEY:$PRIVATE_KEY@default
 ```

--- a/Transport/MailjetApiTransport.php
+++ b/Transport/MailjetApiTransport.php
@@ -133,9 +133,15 @@ class MailjetApiTransport extends AbstractApiTransport
             $message['Headers'][$header->getName()] = $header->getBodyAsString();
         }
 
-        return [
+        $returnArray = [
             'Messages' => [$message],
         ];
+
+        if ($this->sandbox) {
+            $returnArray['SandboxMode']=true;
+        }
+
+        return $returnArray;
     }
 
     private function formatAddresses(array $addresses): array

--- a/Transport/MailjetApiTransport.php
+++ b/Transport/MailjetApiTransport.php
@@ -41,6 +41,7 @@ class MailjetApiTransport extends AbstractApiTransport
 
     private $privateKey;
     private $publicKey;
+    private $sandbox;
 
     public function __construct(string $publicKey, string $privateKey, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {

--- a/Transport/MailjetTransportFactory.php
+++ b/Transport/MailjetTransportFactory.php
@@ -24,9 +24,10 @@ class MailjetTransportFactory extends AbstractTransportFactory
         $user = $this->getUser($dsn);
         $password = $this->getPassword($dsn);
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+        $sandbox = $dsn->getOption('sandbox') === 'true' ? true : false;
 
         if ('mailjet+api' === $scheme) {
-            return (new MailjetApiTransport($user, $password, $this->client, $this->dispatcher, $this->logger))->setHost($host);
+            return (new MailjetApiTransport($user, $password, $sandbox, $this->client, $this->dispatcher, $this->logger))->setHost($host);
         }
 
         if (\in_array($scheme, ['mailjet+smtp', 'mailjet+smtps', 'mailjet'])) {


### PR DESCRIPTION
Mailjet introduced a Sandbox Mode https://dev.mailjet.com/email/guides/send-api-v31/#sandbox-mode that allows to use the API but not sending any email e.g. for debugging.

Example
MAILER_DSN=mailjet+api://$PUBLIC_KEY:$PRIVATE_KEY@default?sandbox=true